### PR TITLE
README: Update Python API pip install index-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Below are main features. Jupyter notebook examples can be found [here](https://c
 - Bloomberg official Python API:
 
 ```cmd
-pip install blpapi --index-url=https://bcms.bloomberg.com/pip/simple/
+pip install blpapi --index-url=https://blpapi.bloomberg.com/repository/releases/python/simple
 ```
 
 - `numpy`, `pandas`, `ruamel.yaml` and `pyarrow`


### PR DESCRIPTION
According to https://www.bloomberg.com/professional/support/api-library/. The previous command didn't work for me.